### PR TITLE
Fixed PUMP_UPDATE_ONLINE event, pointer casted to int instead of dereferencing

### DIFF
--- a/src/P23.MetaTrader4.Manager.ClrWrapper/PumpingExtended.cpp
+++ b/src/P23.MetaTrader4.Manager.ClrWrapper/PumpingExtended.cpp
@@ -53,7 +53,7 @@ void P23::MetaTrader4::Manager::ClrWrapper::ExtendedPumpingNotify(int code, int 
 		case PUMP_UPDATE_ONLINE:
 			if (data != NULL)
 			{
-				int onlineLogin = (int)data;
+				int onlineLogin = PtrToInt(data);
 				OnlineUpdated(this, onlineLogin);
 			}
 			break;


### PR DESCRIPTION
Macros used for compatibility with x64 builds